### PR TITLE
feat: Update vlan apis

### DIFF
--- a/lib/resources/virtual-networks/assignments/index.js
+++ b/lib/resources/virtual-networks/assignments/index.js
@@ -1,33 +1,33 @@
 class Assignments {
   constructor(Maxihost) {
     this.Maxihost = Maxihost;
-    this.baseUrl = "/virtual_networks";
+    this.baseUrl = "/virtual_networks/assignments";
   }
 
   list(searchParams = "") {
     searchParams = new URLSearchParams(searchParams).toString();
     const headers = this.Maxihost._headers;
     return this.Maxihost._get(
-      `${this.baseUrl}/assignments`,
+      this.baseUrl,
       headers,
       searchParams
     );
   }
 
-  create(vlan_id, bodyData) {
+  create(bodyData) {
     const headers = this.Maxihost._headers;
     return this.Maxihost._post(
-      this.baseUrl + '/' + vlan_id + "/assignments",
+      this.baseUrl,
       headers,
       bodyData
     );
   }
 
-  delete(vlan_id, id) {
+  delete(id) {
     const headers = this.Maxihost._headers;
     return this.Maxihost._delete(
-      this.baseUrl + '/' + vlan_id + "/assignments/" + id,
-      headers
+      `${this.baseUrl}/${id}`,
+      headers,
     );
   }
 }

--- a/lib/resources/virtual-networks/assignments/test.js
+++ b/lib/resources/virtual-networks/assignments/test.js
@@ -36,15 +36,18 @@ describe("list assignments", () => {
 
 describe("create assignments", () => {
   it("call post request with right params", async () => {
-    const path = "/virtual_networks/" + vlan_id + "/assignments";
+    const path = "/virtual_networks/assignments";
     Maxihost._post = jest.fn(() => {
       return { body: { success: true } };
     });
-    maxihostApi.VirtualNetworks.Assignments.create(vlan_id, data);
+    maxihostApi.VirtualNetworks.Assignments.create({
+      server_id: 1,
+      vlan_id: 2
+    });
     await expect(Maxihost._post).toHaveBeenCalledWith(
       path,
       Maxihost._headers,
-      data
+      { server_id: 1, vlan_id: 2 }
     );
   });
 
@@ -61,11 +64,11 @@ describe("create assignments", () => {
 
 describe("delete assignments", () => {
   it("call delete request with right params", async () => {
-    const path = "/virtual_networks/" + vlan_id + "/assignments/" + id;
+    const path = "/virtual_networks/assignments/" + id;
     Maxihost._delete = jest.fn(() => {
       return { body: { success: true } };
     });
-    maxihostApi.VirtualNetworks.Assignments.delete(vlan_id, id);
+    maxihostApi.VirtualNetworks.Assignments.delete(id);
     await expect(Maxihost._delete).toHaveBeenCalledWith(
       path,
       Maxihost._headers

--- a/lib/resources/virtual-networks/index.js
+++ b/lib/resources/virtual-networks/index.js
@@ -6,15 +6,21 @@ class VirtualNetworks {
     this.baseUrl = "/virtual_networks";
   }
 
+  get(id, searchParams = "") {
+    searchParams = new URLSearchParams(searchParams).toString();
+    const headers = this.Maxihost._headers;
+    return this.Maxihost._get(`${this.baseUrl}/${id}`, headers, searchParams);
+  }
+
   list(searchParams = "") {
     searchParams = new URLSearchParams(searchParams).toString();
     const headers = this.Maxihost._headers;
     return this.Maxihost._get(this.baseUrl, headers, searchParams);
   }
 
-  update(vlan_id, bodyData) {
+  update(bodyData) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._put(this.baseUrl + '/' +  vlan_id, headers, bodyData);
+    return this.Maxihost._put(this.baseUrl, headers, bodyData);
   }
 
   create(bodyData) {
@@ -22,9 +28,9 @@ class VirtualNetworks {
     return this.Maxihost._post(this.baseUrl, headers, bodyData);
   }
 
-  delete(vlan_id) {
+  delete(id) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._delete(this.baseUrl  + '/' + vlan_id, headers);
+    return this.Maxihost._delete(`${this.baseUrl}/${id}`, headers);
   }
 }
 

--- a/lib/resources/virtual-networks/test.js
+++ b/lib/resources/virtual-networks/test.js
@@ -1,9 +1,6 @@
 import Maxihost from "../../maxihost.js";
 const maxihostApi = new Maxihost("fake token");
 
-const searchParams = { region: "MH1" };
-const searchParamsParsed = "region=MH1";
-
 const virtualNetworkId = 1;
 
 const data = {
@@ -21,11 +18,11 @@ describe("list virtual networks", () => {
     Maxihost._get = jest.fn(() => {
       return { body: { success: true } };
     });
-    maxihostApi.VirtualNetworks.list(searchParams);
+    maxihostApi.VirtualNetworks.list({ 'filter[project]': 'test-project'});
     await expect(Maxihost._get).toHaveBeenCalledWith(
       path,
       Maxihost._headers,
-      searchParamsParsed
+      'filter%5Bproject%5D=test-project'
     );
   });
 


### PR DESCRIPTION
This PR adds support for getting vlans by id and other vlan related crud operations.

There might be further tweaks required after the backend apis are ready.