### PR TITLE
chore: Change patch to put

### DIFF
--- a/lib/resources/projects/user-data/index.js
+++ b/lib/resources/projects/user-data/index.js
@@ -25,7 +25,7 @@ class UserData {
 
   update(projectIdOrSlug, userDataId, bodyData) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._patch(
+    return this.Maxihost._put(
       `${this.baseUrl}/${projectIdOrSlug}/user_data/${userDataId}`,
       headers,
       bodyData);


### PR DESCRIPTION
Although updating user data seems to work with a patch request, the specification uses put https://github.com/Maxihost/API/blob/edfc6e6dacd4a0e0bcb72c419840856564c34052/swagger/v2/swagger.json#L7227. So this PR changes the patch request to put.