### PR TITLE
Feat/pd 2234/update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,50 +94,50 @@ maxihostApi.Profile.get().then((response) => {
 - `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/create-ipmi-session)
 
 
-- `Teams.current`. Params: `(searchParams)`. [Reference]()
-- `Teams.update`. Params: `(teamId, data)`. [Reference]()
-- `Teams.create`. Params: `(bodyData)`. [Reference]()
+- `Teams.current`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team)
+- `Teams.update`. Params: `(teamId, data)`. [Reference](https://docs.maxihost.com/reference/patch-current-team)
+- `Teams.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-team)
 
 
-- `Teams.Members.list`. Params: `(searchParams)`. [Reference]()
-- `Teams.Members.create`. Params: `(bodyData)`. [Reference]()
-- `Teams.Members.delete`. Params: `(memberId)`. [Reference]()
+- `Teams.Members.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
+- `Teams.Members.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-team-members)
+- `Teams.Members.delete`. Params: `(memberId)`. [Reference](https://docs.maxihost.com/reference/destroy-team-member)
 
 
-- `Teams.User.listTeams`. Params: `(searchParams)`. [Reference]()
+- `Teams.User.listTeams`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
 
 
-- `Traffic.get`. Params: `(searchParams)`. [Reference]()
+- `Traffic.get`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-traffic-consumption)
  
 
-- `Traffic.Quota.get`. Params: `(projectSlug)`. [Reference]()
+- `Traffic.Quota.get`. Params: `(projectSlug)`. [Reference](https://docs.maxihost.com/reference/get-traffic-quota)
 
 
-- `User.ApiKeys.list Params: `(searchParams)`. [Reference]()
-- `User.ApiKeys.update Params: `(apiKeyId, bodyData)`. [Reference]()
-- `User.ApiKeys.create Params: `(bodyData)`. [Reference]()
-- `User.ApiKeys.delete Params: `(apiKeyId)`. [Reference]()
+- `User.ApiKeys.list Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-api-keys)
+- `User.ApiKeys.update Params: `(apiKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-api-key)
+- `User.ApiKeys.create Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-api-key)
+- `User.ApiKeys.delete Params: `(apiKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-api-key)
 
 
-- `User.Profile.get Params: `(searchParams)`. [Reference]()
-- `User.Profile.update Params: `(userId, data)`. [Reference]()
+- `User.Profile.get Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-user-profile)
+- `User.Profile.update Params: `(userId, data)`. [Reference](https://docs.maxihost.com/reference/patch-user-profile)
 
 
-- `VirtualNetworks.get`. Params: `(id, searchParams)`. [Reference]()
-- `VirtualNetworks.list`. Params: `(searchParams)`. [Reference]()
-- `VirtualNetworks.update`. Params: `(id, bodyData)`. [Reference]()
-- `VirtualNetworks.create`. Params: `(bodyData)`. [Reference]()
-- `VirtualNetworks.delete`. Params: `(id)`. [Reference]()
+- `VirtualNetworks.get`. Params: `(id, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-virtual-network)
+- `VirtualNetworks.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-virtual-networks)
+- `VirtualNetworks.update`. Params: `(id, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-virtual-network)
+- `VirtualNetworks.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-virtual-network)
+- `VirtualNetworks.delete`. Params: `(id)`. [Reference](https://docs.maxihost.com/reference/destroy-virtual-network)
 
 
-- `VirtualNetworks.Assignments.list`. Params: `(searchParams)`. [Reference]()
-- `VirtualNetworks.Assignments.create`. Params: `(bodyData)`. [Reference]()
-- `VirtualNetworks.Assignments.delete`. Params: `(id)`. [Reference]()
+- `VirtualNetworks.Assignments.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-virtual-networks-assignments)
+- `VirtualNetworks.Assignments.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/assign-server-virtual-network)
+- `VirtualNetworks.Assignments.delete`. Params: `(id)`. [Reference](https://docs.maxihost.com/reference/delete-virtual-networks-assignments)
 
 
-- `VpnSessions.list`. Params: `(searchParams)`. [Reference]()
-- `VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference]()
-- `VpnSessions.create`. Params: `(bodyData)`. [Reference]()
-- `VpnSessions.delete`. Params: `(sessionId)`. [Reference]()
+- `VpnSessions.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-vpn-sessions)
+- `VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference](https://docs.maxihost.com/reference/put-vpn-session)
+- `VpnSessions.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-vpn-session)
+- `VpnSessions.delete`. Params: `(sessionId)`. [Reference](https://docs.maxihost.com/reference/delete-vpn-session)
 
 

--- a/README.md
+++ b/README.md
@@ -90,26 +90,31 @@ maxihostApi.Profile.get().then((response) => {
 - 
 - `Teams.User.listTeams`. Params: `(searchParams)`. [Reference]()
 - 
-- `Device.list`. SearchParams: `limit, page, status`. [Reference](https://developers.maxihost.com/reference#list-servers-1)
-- `Device.get`. Params: `deviceId`. [Reference](https://developers.maxihost.com/reference#retrieve-server-1)
-- `Device.create`. Params: `facility, plan, hostname, operating_system, billing_cycle, ssh_keys, custom_scripts, raid`. [Reference](https://developers.maxihost.com/reference#create-server-1)
-- `Device.delete`. Params: `deviceId`. [Reference](https://developers.maxihost.com/reference#delete-server-1)
-- `Device.Bandwidth.get`. Params: `deviceId`. SearchParams: `output_format, period, start_time, end_time`. [Reference](https://developers.maxihost.com/reference#retrieve-server-bandwidth-1)
-- `Device.Actions.manage_power`. Params: `id, type`. [Reference](https://developers.maxihost.com/reference#server-power-management-1)
-- `Device.Actions.getReinstall`. Params: `id`. [Reference](https://developers.maxihost.com/reference#reinstall-eligibility-1)
-- `Device.Actions.reinstall`. Params: `id, label, operating_system, ssh`. [Reference](https://developers.maxihost.com/reference#reinstall-server-1)
-- `Device.Actions.remote_access`. Params: `id`. [Reference](https://developers.maxihost.com/reference#create-ipmi-session-1)
-- `Device.CustomScripts.list`. Params: `page, limit`. [Reference](https://developers.maxihost.com/reference#custom-scripts-get)
-- `Device.CustomScripts.update`. Params: `id, name, content`. [Reference](https://developers.maxihost.com/reference#custom-scripts-id-put)
-- `Device.CustomScripts.delete`. Params: `id`. [Reference](https://developers.maxihost.com/reference#custom-script-id-delete)
-- `Device.CustomScripts.create`. Params: `name, content`. [Reference](https://developers.maxihost.com/reference#custom-script-post)
-- `Account.Regions`. Params: `page, limit`. [Reference](https://developers.maxihost.com/reference#list-regions-1)
-- `VirtualNetworks.list`. Params: `region`. [Reference](https://developers.maxihost.com/reference#get_virtual-networks)
-- `VirtualNetworks.create`. Params: `region, description`. [Reference](https://developers.maxihost.com/reference#post_virtual-networks)
-- `VirtualNetworks.update`. Params: `vid, description`. [Reference](https://developers.maxihost.com/reference#put_virtual-networks-vlan-id)
-- `VirtualNetworks.delete`. Params: `vid`. [Reference](https://developers.maxihost.com/reference#delete_virtual-networks-vlan-id)
-- `VirtualNetworks.Assignments.list`. Params: `vid`. [Reference](https://developers.maxihost.com/reference#virtual-network-assignments)
+- `Traffic.get`. Params: `(searchParams)`. [Reference]()
+- `Traffic.Quota`. Params: `(searchParams)`. [Reference]()
+- `Traffic.Quota.get`. Params: `(projectSlug)`. [Reference]()
+- 
+- `User.ApiKeys.list Params: `(searchParams)`. [Reference]()
+- `User.ApiKeys.update Params: `(apiKeyId, bodyData)`. [Reference]()
+- `User.ApiKeys.create Params: `(bodyData)`. [Reference]()
+- `User.ApiKeys.delete Params: `(apiKeyId)`. [Reference]()
+- 
+- `User.Profile.get Params: `(searchParams)`. [Reference]()
+- `User.Profile.update Params: `(userId, data)`. [Reference]()
+- 
+- `VirtualNetworks.get`. Params: `id, searchParams`. [Reference]()
+- `VirtualNetworks.list`. Params: `searchParams`. [Reference]()
+- `VirtualNetworks.create`. Params: `bodyData`. [Reference]()
+- `VirtualNetworks.update`. Params: `id, bodyData`. [Reference]()
+- `VirtualNetworks.delete`. Params: `id`. [Reference]()
+- 
+- `VirtualNetworks.Assignments.list`. Params: `searchParams`. [Reference]()
+- `VirtualNetworks.Assignments.create`. Params: `bodyData`. [Reference]()
+- `VirtualNetworks.Assignments.delete`. Params: `id`. [Reference]()
+- 
+- `VirtualNetworks.VpnSessions.list`. Params: `searchParams`. [Reference]()
+- `VirtualNetworks.VpnSessions.refreshPassword`. Params: `searchParams`. [Reference]()
+- `VirtualNetworks.VpnSessions.create`. Params: `searchParams`. [Reference]()
+- `VirtualNetworks.VpnSessions.delete`. Params: `searchParams`. [Reference]()
+- 
 
-- `Profile.get`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-user-profile)
-- `Teams.current`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-team)
-- `Teams.User.listTeams`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-user-teams)

--- a/README.md
+++ b/README.md
@@ -80,18 +80,18 @@ maxihostApi.Profile.get().then((response) => {
 
 - `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.maxihost.com/reference/create-server-action)
 - `Server.Actions.getReinstall`. Params: `(serverId)`. [Reference]()
-- `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference]()
+- `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/create-server-reinstall)
 - `Server.Actions.getRemoteAccess`. Params: `(serverId)`. [Reference]()
 
 
-- `Server.DeployConfig.get`. Params: `(serverId)`. [Reference]()
-- `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference]()
+- `Server.DeployConfig.get`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/get-server-deploy-config)
+- `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-server-deploy-config)
 
 
-- `Server.Ips.list`. Params: `(serverId, searchParams)`. [Reference]()
+- `Server.Ips.list`. Params: `(serverId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-ips)
 
 
-- `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference]()
+- `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/create-ipmi-session)
 
 
 - `Teams.current`. Params: `(searchParams)`. [Reference]()

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ maxihostApi.Profile.get().then((response) => {
 
 # Available API Methods
 
+- `Account.Regions.list`. Params: `(searchParams)`. ***Deprecated***
+
+
 - `Ips.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-ips)
 
 
@@ -79,16 +82,16 @@ maxihostApi.Profile.get().then((response) => {
 
 
 - `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.maxihost.com/reference/create-server-action)
--  Deprecated: `Server.Actions.getReinstall`. Params: `(serverId)`.
+- `Server.Actions.getReinstall`. Params: `(serverId)`. ***Deprecated***
 - `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/create-server-reinstall)
--  Deprecated: `Server.Actions.getRemoteAccess`. Params: `(serverId)`.
+- `Server.Actions.getRemoteAccess`. Params: `(serverId)`. ***Deprecated***
 
 
 - `Server.DeployConfig.get`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/get-server-deploy-config)
 - `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-server-deploy-config)
 
 
-- Deprecated: Use Ips.list instead.`Server.Ips.list`. Params: `(serverId, searchParams)`.
+- `Server.Ips.list`. Params: `(serverId, searchParams)`. ***Deprecated***
 
 
 - `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/create-ipmi-session)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ maxihostApi.Profile.get().then((response) => {
 
 # Available API Methods
 
+- `Ips.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-ips)
+- 
+- `Plans.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans)
+- `Plans.get`. Params: `(planId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plan)
+- `Plans.addons`. Params: `(searchParams)`. [Reference]()
+- `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system^)
+- `Plans.Bandwidth.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
+- `Plans.Bandwidth.update`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/update-plans-bandwidth)
+- 
+- `Projects.Members.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
+- `Projects.SshKeys.get`. Params: `(projectId, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
+- `Projects.SshKeys.create`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-ssh-key)
+- `Projects.SshKeys.update`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
+- `Projects.SshKeys.delete`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
+- 
 - `Device.list`. SearchParams: `limit, page, status`. [Reference](https://developers.maxihost.com/reference#list-servers-1)
 - `Device.get`. Params: `deviceId`. [Reference](https://developers.maxihost.com/reference#retrieve-server-1)
 - `Device.create`. Params: `facility, plan, hostname, operating_system, billing_cycle, ssh_keys, custom_scripts, raid`. [Reference](https://developers.maxihost.com/reference#create-server-1)
@@ -40,14 +55,10 @@ maxihostApi.Profile.get().then((response) => {
 - `Device.Actions.getReinstall`. Params: `id`. [Reference](https://developers.maxihost.com/reference#reinstall-eligibility-1)
 - `Device.Actions.reinstall`. Params: `id, label, operating_system, ssh`. [Reference](https://developers.maxihost.com/reference#reinstall-server-1)
 - `Device.Actions.remote_access`. Params: `id`. [Reference](https://developers.maxihost.com/reference#create-ipmi-session-1)
-- `Device.Ips.list`. Params: `page, limit `. [Reference](https://developers.maxihost.com/reference#list-all-ips-1)
 - `Device.CustomScripts.list`. Params: `page, limit`. [Reference](https://developers.maxihost.com/reference#custom-scripts-get)
 - `Device.CustomScripts.update`. Params: `id, name, content`. [Reference](https://developers.maxihost.com/reference#custom-scripts-id-put)
 - `Device.CustomScripts.delete`. Params: `id`. [Reference](https://developers.maxihost.com/reference#custom-script-id-delete)
 - `Device.CustomScripts.create`. Params: `name, content`. [Reference](https://developers.maxihost.com/reference#custom-script-post)
-- `Device.Plans.list`. Params: `page, limit`. [Reference](https://developers.maxihost.com/reference#list-available-servers-1)
-- `Device.Plans.addons`. Params: `page, limit`. [Reference](https://developers.maxihost.com/reference#list-available-addons-1)
-- `Device.Plans.operatingSystems`. Params: `page, limit`. [Reference](https://developers.maxihost.com/reference#list-operating-systems-1)
 - `Account.Regions`. Params: `page, limit`. [Reference](https://developers.maxihost.com/reference#list-regions-1)
 - `VirtualNetworks.list`. Params: `region`. [Reference](https://developers.maxihost.com/reference#get_virtual-networks)
 - `VirtualNetworks.create`. Params: `region, description`. [Reference](https://developers.maxihost.com/reference#post_virtual-networks)
@@ -59,7 +70,6 @@ maxihostApi.Profile.get().then((response) => {
 - `Projects.list`> Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-projects)
 - `Projects.get`. Params: `(projectId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#retrieve-project)
 - `Projects.Ips.list`. Params: `(projectId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-project-ips)
-- `Projects.Members.list`. Params: `(projectId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-project-members)
 - `Projects.Servers.list`. Params: `(projectId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-project-servers)
 - `Projects.Servers.get`. Params: `(projectId, serverId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-project-server)
 - `Regions.list`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-regions)

--- a/README.md
+++ b/README.md
@@ -33,20 +33,25 @@ maxihostApi.Profile.get().then((response) => {
 
 - `Ips.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-ips)
 
+
 - `Plans.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans)
 - `Plans.get`. Params: `(planId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plan)
 - `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system^)
 
+
 - `Plans.Bandwidth.list`. Params: `()`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
 - `Plans.Bandwidth.update`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/update-plans-bandwidth)
-- 
+
+ 
 - `Projects.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-projects)
 - `Projects.get`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project)
 - `Projects.update`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-project)
 - `Projects.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-project)
 - `Projects.delete`. Params: `(idOrSlug)`. [Reference](https://docs.maxihost.com/reference/delete-project)
 
+
 - `Projects.Members.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
+
 
 - `Projects.SshKeys.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-keys)
 - `Projects.SshKeys.get`. Params: `(projectId, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
@@ -54,14 +59,17 @@ maxihostApi.Profile.get().then((response) => {
 - `Projects.SshKeys.update`. Params: `(projectId, sskKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
 - `Projects.SshKeys.delete`. Params: `(projectId, sshKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
 
+
 - `Projects.UserData.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-users-data)
 - `Projects.UserData.get`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-user-data)
 - `Projects.UserData.update`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/put-project-user-data)
 - `Projects.UserData.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-user-data)
 - `Projects.UserData.delete`. Params: `(projectIdOrSlug, userDataId)`. [Reference](https://docs.maxihost.com/reference/delete-project-user-data)
 
+
 - `Regions.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-regions)
 - `Regions.get`. Params: `(regionId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-region)
+
 
 - `Server.get`. Params: `(deviceId, searchParams)` [Reference](https://docs.maxihost.com/reference/get-server)
 - `Server.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-servers)
@@ -69,39 +77,51 @@ maxihostApi.Profile.get().then((response) => {
 - `Server.update`. Params: `(deviceId, bodyData)` [Reference](https://docs.maxihost.com/reference/update-server)
 - `Server.delete`. Params: `(deviceId)` [Reference](https://docs.maxihost.com/reference/destroy-server)
 
+
 - `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.maxihost.com/reference/create-server-action)
 - `Server.Actions.getReinstall`. Params: `(serverId)`. [Reference]()
 - `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference]()
 - `Server.Actions.getRemoteAccess`. Params: `(serverId)`. [Reference]()
 
+
 - `Server.DeployConfig.get`. Params: `(serverId)`. [Reference]()
 - `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference]()
 
+
 - `Server.Ips.list`. Params: `(serverId, searchParams)`. [Reference]()
 
+
 - `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference]()
+
 
 - `Teams.current`. Params: `(searchParams)`. [Reference]()
 - `Teams.update`. Params: `(teamId, data)`. [Reference]()
 - `Teams.create`. Params: `(bodyData)`. [Reference]()
 
+
 - `Teams.Members.list`. Params: `(searchParams)`. [Reference]()
 - `Teams.Members.create`. Params: `(bodyData)`. [Reference]()
 - `Teams.Members.delete`. Params: `(memberId)`. [Reference]()
 
+
 - `Teams.User.listTeams`. Params: `(searchParams)`. [Reference]()
+
 
 - `Traffic.get`. Params: `(searchParams)`. [Reference]()
  
+
 - `Traffic.Quota.get`. Params: `(projectSlug)`. [Reference]()
+
 
 - `User.ApiKeys.list Params: `(searchParams)`. [Reference]()
 - `User.ApiKeys.update Params: `(apiKeyId, bodyData)`. [Reference]()
 - `User.ApiKeys.create Params: `(bodyData)`. [Reference]()
 - `User.ApiKeys.delete Params: `(apiKeyId)`. [Reference]()
 
+
 - `User.Profile.get Params: `(searchParams)`. [Reference]()
 - `User.Profile.update Params: `(userId, data)`. [Reference]()
+
 
 - `VirtualNetworks.get`. Params: `(id, searchParams)`. [Reference]()
 - `VirtualNetworks.list`. Params: `(searchParams)`. [Reference]()
@@ -109,9 +129,11 @@ maxihostApi.Profile.get().then((response) => {
 - `VirtualNetworks.create`. Params: `(bodyData)`. [Reference]()
 - `VirtualNetworks.delete`. Params: `(id)`. [Reference]()
 
+
 - `VirtualNetworks.Assignments.list`. Params: `(searchParams)`. [Reference]()
 - `VirtualNetworks.Assignments.create`. Params: `(bodyData)`. [Reference]()
 - `VirtualNetworks.Assignments.delete`. Params: `(id)`. [Reference]()
+
 
 - `VpnSessions.list`. Params: `(searchParams)`. [Reference]()
 - `VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference]()

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ maxihostApi.Profile.get().then((response) => {
 # Available API Methods
 
 - `Ips.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-ips)
-- 
+
 - `Plans.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans)
 - `Plans.get`. Params: `(planId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plan)
 - `Plans.addons`. Params: `(searchParams)`. [Reference]()
 - `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system^)
-- `Plans.Bandwidth.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
+
+- `Plans.Bandwidth.list`. Params: `()`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
 - `Plans.Bandwidth.update`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/update-plans-bandwidth)
 - 
 - `Projects.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-projects)
@@ -45,76 +46,77 @@ maxihostApi.Profile.get().then((response) => {
 - `Projects.update`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-project)
 - `Projects.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-project)
 - `Projects.delete`. Params: `(idOrSlug)`. [Reference](https://docs.maxihost.com/reference/delete-project)
-- 
+
 - `Projects.Members.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
-- 
+
+- `Projects.SshKeys.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
 - `Projects.SshKeys.get`. Params: `(projectId, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
 - `Projects.SshKeys.create`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-ssh-key)
-- `Projects.SshKeys.update`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
-- `Projects.SshKeys.delete`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
-- 
+- `Projects.SshKeys.update`. Params: `(projectId, sskKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
+- `Projects.SshKeys.delete`. Params: `(projectId, sshKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
+
 - `Projects.UserData.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-users-data)
 - `Projects.UserData.get`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference]()
 - `Projects.UserData.update`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference]()
 - `Projects.UserData.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference]()
 - `Projects.UserData.delete`. Params: `(projectIdOrSlug, userDataId)`. [Reference]()
-- 
+
 - `Regions.list`. Params: `(searchParams)` [Reference]()
 - `Regions.get`. Params: `(regionId, searchParams)`. [Reference]()
-- 
-- `Server.get`. Params: `(serverId, searchParams)` [Reference]()
+
+- `Server.get`. Params: `(deviceId, searchParams)` [Reference]()
 - `Server.list`. Params: `(searchParams)` [Reference]()
-- `Server.create`. Params: `(deviceId, bodyData)` [Reference]()
+- `Server.create`. Params: `(bodyData)` [Reference]()
 - `Server.update`. Params: `(deviceId, bodyData)` [Reference]()
 - `Server.delete`. Params: `(deviceId)` [Reference]()
-- 
+
 - `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference]()
 - `Server.Actions.getReinstall`. Params: `(serverId)`. [Reference]()
 - `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference]()
 - `Server.Actions.getRemoteAccess`. Params: `(serverId)`. [Reference]()
-- 
+
 - `Server.DeployConfig.get`. Params: `(serverId)`. [Reference]()
 - `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference]()
-- 
+
 - `Server.Ips.list`. Params: `(serverId, searchParams)`. [Reference]()
-- 
+
 - `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference]()
-- 
+
 - `Teams.current`. Params: `(searchParams)`. [Reference]()
 - `Teams.update`. Params: `(teamId, data)`. [Reference]()
 - `Teams.create`. Params: `(bodyData)`. [Reference]()
-- 
+
 - `Teams.Members.list`. Params: `(searchParams)`. [Reference]()
 - `Teams.Members.create`. Params: `(bodyData)`. [Reference]()
 - `Teams.Members.delete`. Params: `(memberId)`. [Reference]()
-- 
+
 - `Teams.User.listTeams`. Params: `(searchParams)`. [Reference]()
-- 
+
 - `Traffic.get`. Params: `(searchParams)`. [Reference]()
-- `Traffic.Quota`. Params: `(searchParams)`. [Reference]()
+ 
 - `Traffic.Quota.get`. Params: `(projectSlug)`. [Reference]()
-- 
+
 - `User.ApiKeys.list Params: `(searchParams)`. [Reference]()
 - `User.ApiKeys.update Params: `(apiKeyId, bodyData)`. [Reference]()
 - `User.ApiKeys.create Params: `(bodyData)`. [Reference]()
 - `User.ApiKeys.delete Params: `(apiKeyId)`. [Reference]()
-- 
+
 - `User.Profile.get Params: `(searchParams)`. [Reference]()
 - `User.Profile.update Params: `(userId, data)`. [Reference]()
-- 
-- `VirtualNetworks.get`. Params: `id, searchParams`. [Reference]()
-- `VirtualNetworks.list`. Params: `searchParams`. [Reference]()
-- `VirtualNetworks.create`. Params: `bodyData`. [Reference]()
-- `VirtualNetworks.update`. Params: `id, bodyData`. [Reference]()
-- `VirtualNetworks.delete`. Params: `id`. [Reference]()
-- 
-- `VirtualNetworks.Assignments.list`. Params: `searchParams`. [Reference]()
-- `VirtualNetworks.Assignments.create`. Params: `bodyData`. [Reference]()
-- `VirtualNetworks.Assignments.delete`. Params: `id`. [Reference]()
-- 
-- `VirtualNetworks.VpnSessions.list`. Params: `searchParams`. [Reference]()
-- `VirtualNetworks.VpnSessions.refreshPassword`. Params: `searchParams`. [Reference]()
-- `VirtualNetworks.VpnSessions.create`. Params: `searchParams`. [Reference]()
-- `VirtualNetworks.VpnSessions.delete`. Params: `searchParams`. [Reference]()
-- 
+
+- `VirtualNetworks.get`. Params: `(id, searchParams)`. [Reference]()
+- `VirtualNetworks.list`. Params: `(searchParams)`. [Reference]()
+- `VirtualNetworks.update`. Params: `(id, bodyData)`. [Reference]()
+- `VirtualNetworks.create`. Params: `(bodyData)`. [Reference]()
+- `VirtualNetworks.delete`. Params: `(id)`. [Reference]()
+
+- `VirtualNetworks.Assignments.list`. Params: `(searchParams)`. [Reference]()
+- `VirtualNetworks.Assignments.create`. Params: `(bodyData)`. [Reference]()
+- `VirtualNetworks.Assignments.delete`. Params: `(id)`. [Reference]()
+
+- `VirtualNetworks.VpnSessions.list`. Params: `(searchParams)`. [Reference]()
+- `VirtualNetworks.VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference]()
+- `VirtualNetworks.VpnSessions.create`. Params: `(bodyData)`. [Reference]()
+- `VirtualNetworks.VpnSessions.delete`. Params: `(sessionId)`. [Reference]()
+
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ maxihostApi.Profile.get().then((response) => {
 - `VirtualNetworks.Assignments.create`. Params: `(bodyData)`. [Reference]()
 - `VirtualNetworks.Assignments.delete`. Params: `(id)`. [Reference]()
 
-- `VirtualNetworks.VpnSessions.list`. Params: `(searchParams)`. [Reference]()
-- `VirtualNetworks.VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference]()
-- `VirtualNetworks.VpnSessions.create`. Params: `(bodyData)`. [Reference]()
-- `VirtualNetworks.VpnSessions.delete`. Params: `(sessionId)`. [Reference]()
+- `VpnSessions.list`. Params: `(searchParams)`. [Reference]()
+- `VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference]()
+- `VpnSessions.create`. Params: `(bodyData)`. [Reference]()
+- `VpnSessions.delete`. Params: `(sessionId)`. [Reference]()
 
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,55 @@ maxihostApi.Profile.get().then((response) => {
 - `Plans.Bandwidth.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
 - `Plans.Bandwidth.update`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/update-plans-bandwidth)
 - 
+- `Projects.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-projects)
+- `Projects.get`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project)
+- `Projects.update`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-project)
+- `Projects.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-project)
+- `Projects.delete`. Params: `(idOrSlug)`. [Reference](https://docs.maxihost.com/reference/delete-project)
+- 
 - `Projects.Members.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
+- 
 - `Projects.SshKeys.get`. Params: `(projectId, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
 - `Projects.SshKeys.create`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-ssh-key)
 - `Projects.SshKeys.update`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
 - `Projects.SshKeys.delete`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
+- 
+- `Projects.UserData.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-users-data)
+- `Projects.UserData.get`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference]()
+- `Projects.UserData.update`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference]()
+- `Projects.UserData.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference]()
+- `Projects.UserData.delete`. Params: `(projectIdOrSlug, userDataId)`. [Reference]()
+- 
+- `Regions.list`. Params: `(searchParams)` [Reference]()
+- `Regions.get`. Params: `(regionId, searchParams)`. [Reference]()
+- 
+- `Server.get`. Params: `(serverId, searchParams)` [Reference]()
+- `Server.list`. Params: `(searchParams)` [Reference]()
+- `Server.create`. Params: `(deviceId, bodyData)` [Reference]()
+- `Server.update`. Params: `(deviceId, bodyData)` [Reference]()
+- `Server.delete`. Params: `(deviceId)` [Reference]()
+- 
+- `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference]()
+- `Server.Actions.getReinstall`. Params: `(serverId)`. [Reference]()
+- `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference]()
+- `Server.Actions.getRemoteAccess`. Params: `(serverId)`. [Reference]()
+- 
+- `Server.DeployConfig.get`. Params: `(serverId)`. [Reference]()
+- `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference]()
+- 
+- `Server.Ips.list`. Params: `(serverId, searchParams)`. [Reference]()
+- 
+- `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference]()
+- 
+- `Teams.current`. Params: `(searchParams)`. [Reference]()
+- `Teams.update`. Params: `(teamId, data)`. [Reference]()
+- `Teams.create`. Params: `(bodyData)`. [Reference]()
+- 
+- `Teams.Members.list`. Params: `(searchParams)`. [Reference]()
+- `Teams.Members.create`. Params: `(bodyData)`. [Reference]()
+- `Teams.Members.delete`. Params: `(memberId)`. [Reference]()
+- 
+- `Teams.User.listTeams`. Params: `(searchParams)`. [Reference]()
 - 
 - `Device.list`. SearchParams: `limit, page, status`. [Reference](https://developers.maxihost.com/reference#list-servers-1)
 - `Device.get`. Params: `deviceId`. [Reference](https://developers.maxihost.com/reference#retrieve-server-1)
@@ -67,12 +111,5 @@ maxihostApi.Profile.get().then((response) => {
 - `VirtualNetworks.Assignments.list`. Params: `vid`. [Reference](https://developers.maxihost.com/reference#virtual-network-assignments)
 
 - `Profile.get`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-user-profile)
-- `Projects.list`> Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-projects)
-- `Projects.get`. Params: `(projectId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#retrieve-project)
-- `Projects.Ips.list`. Params: `(projectId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-project-ips)
-- `Projects.Servers.list`. Params: `(projectId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-project-servers)
-- `Projects.Servers.get`. Params: `(projectId, serverId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-project-server)
-- `Regions.list`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-regions)
-- `Regions.get`. Params: `(regionId, searchParams)`. [Reference](https://developers.maxihost.com/v2.0/reference#get-region-id)
 - `Teams.current`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-team)
 - `Teams.User.listTeams`. Params: `(searchParams)` [Reference](https://developers.maxihost.com/v2.0/reference#get-user-teams)

--- a/README.md
+++ b/README.md
@@ -37,54 +37,47 @@ maxihostApi.Profile.get().then((response) => {
 - `Ips.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-ips)
 
 
-- `Plans.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans)
-- `Plans.get`. Params: `(planId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plan)
-- `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system)
-
-
 - `Plans.Bandwidth.list`. Params: `()`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
 - `Plans.Bandwidth.update`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/update-plans-bandwidth)
 
- 
-- `Projects.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-projects)
-- `Projects.get`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project)
-- `Projects.update`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-project)
-- `Projects.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-project)
-- `Projects.delete`. Params: `(projectIdOrSlug)`. [Reference](https://docs.maxihost.com/reference/delete-project)
+
+- `Plans.get`. Params: `(planId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plan)
+- `Plans.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans)
+- `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system)
 
 
 - `Projects.Members.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
 
 
-- `Projects.SshKeys.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-keys)
-- `Projects.SshKeys.get`. Params: `(projectIdOrSlug, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
 - `Projects.SshKeys.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-ssh-key)
-- `Projects.SshKeys.update`. Params: `(projectIdOrSlug, sskKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
 - `Projects.SshKeys.delete`. Params: `(projectIdOrSlug, sshKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
+- `Projects.SshKeys.get`. Params: `(projectIdOrSlug, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
+- `Projects.SshKeys.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-keys)
+- `Projects.SshKeys.update`. Params: `(projectIdOrSlug, sskKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
 
 
-- `Projects.UserData.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-users-data)
-- `Projects.UserData.get`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-user-data)
-- `Projects.UserData.update`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/put-project-user-data)
 - `Projects.UserData.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-user-data)
 - `Projects.UserData.delete`. Params: `(projectIdOrSlug, userDataId)`. [Reference](https://docs.maxihost.com/reference/delete-project-user-data)
+- `Projects.UserData.get`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-user-data)
+- `Projects.UserData.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-users-data)
+- `Projects.UserData.update`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/put-project-user-data)
 
 
-- `Regions.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-regions)
+- `Projects.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-project)
+- `Projects.delete`. Params: `(projectIdOrSlug)`. [Reference](https://docs.maxihost.com/reference/delete-project)
+- `Projects.get`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project)
+- `Projects.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-projects)
+- `Projects.update`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-project)
+
+
 - `Regions.get`. Params: `(regionId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-region)
+- `Regions.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-regions)
 
 
-- `Server.get`. Params: `(deviceId, searchParams)` [Reference](https://docs.maxihost.com/reference/get-server)
-- `Server.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-servers)
-- `Server.create`. Params: `(bodyData)` [Reference](https://docs.maxihost.com/reference/create-server)
-- `Server.update`. Params: `(deviceId, bodyData)` [Reference](https://docs.maxihost.com/reference/update-server)
-- `Server.delete`. Params: `(deviceId)` [Reference](https://docs.maxihost.com/reference/destroy-server)
-
-
-- `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.maxihost.com/reference/create-server-action)
 - `Server.Actions.getReinstall`. Params: `(serverId)`. ***Deprecated***
-- `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/create-server-reinstall)
 - `Server.Actions.getRemoteAccess`. Params: `(serverId)`. ***Deprecated***
+- `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.maxihost.com/reference/create-server-action)
+- `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/create-server-reinstall)
 
 
 - `Server.DeployConfig.get`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/get-server-deploy-config)
@@ -92,55 +85,56 @@ maxihostApi.Profile.get().then((response) => {
 
 
 - `Server.Ips.list`. Params: `(serverId, searchParams)`. ***Deprecated***
-
-
 - `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/create-ipmi-session)
+- `Server.create`. Params: `(bodyData)` [Reference](https://docs.maxihost.com/reference/create-server)
+- `Server.delete`. Params: `(deviceId)` [Reference](https://docs.maxihost.com/reference/destroy-server)
+- `Server.get`. Params: `(deviceId, searchParams)` [Reference](https://docs.maxihost.com/reference/get-server)
+- `Server.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-servers)
+- `Server.update`. Params: `(deviceId, bodyData)` [Reference](https://docs.maxihost.com/reference/update-server)
 
 
-- `Teams.current`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team)
-- `Teams.update`. Params: `(teamId, data)`. [Reference](https://docs.maxihost.com/reference/patch-current-team)
-- `Teams.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-team)
-
-
-- `Teams.Members.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
 - `Teams.Members.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-team-members)
 - `Teams.Members.delete`. Params: `(memberId)`. [Reference](https://docs.maxihost.com/reference/destroy-team-member)
+- `Teams.Members.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
 
 
 - `Teams.User.listTeams`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-user-teams)
 
 
-- `Traffic.get`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-traffic-consumption)
- 
+- `Teams.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-team)
+- `Teams.current`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team)
+- `Teams.update`. Params: `(teamId, data)`. [Reference](https://docs.maxihost.com/reference/patch-current-team)
+
 
 - `Traffic.Quota.get`. Params: `(projectSlug)`. [Reference](https://docs.maxihost.com/reference/get-traffic-quota)
+- `Traffic.get`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-traffic-consumption)
 
 
-- `User.ApiKeys.list Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-api-keys)
-- `User.ApiKeys.update Params: `(apiKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-api-key)
 - `User.ApiKeys.create Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-api-key)
 - `User.ApiKeys.delete Params: `(apiKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-api-key)
+- `User.ApiKeys.list Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-api-keys)
+- `User.ApiKeys.update Params: `(apiKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-api-key)
 
 
 - `User.Profile.get Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-user-profile)
 - `User.Profile.update Params: `(userId, data)`. [Reference](https://docs.maxihost.com/reference/patch-user-profile)
 
 
+- `VirtualNetworks.Assignments.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/assign-server-virtual-network)
+- `VirtualNetworks.Assignments.delete`. Params: `(id)`. [Reference](https://docs.maxihost.com/reference/delete-virtual-networks-assignments)
+- `VirtualNetworks.Assignments.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-virtual-networks-assignments)
+
+
+- `VirtualNetworks.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-virtual-network)
+- `VirtualNetworks.delete`. Params: `(id)`. [Reference](https://docs.maxihost.com/reference/destroy-virtual-network)
 - `VirtualNetworks.get`. Params: `(id, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-virtual-network)
 - `VirtualNetworks.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-virtual-networks)
 - `VirtualNetworks.update`. Params: `(id, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-virtual-network)
-- `VirtualNetworks.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-virtual-network)
-- `VirtualNetworks.delete`. Params: `(id)`. [Reference](https://docs.maxihost.com/reference/destroy-virtual-network)
 
 
-- `VirtualNetworks.Assignments.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-virtual-networks-assignments)
-- `VirtualNetworks.Assignments.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/assign-server-virtual-network)
-- `VirtualNetworks.Assignments.delete`. Params: `(id)`. [Reference](https://docs.maxihost.com/reference/delete-virtual-networks-assignments)
-
-
-- `VpnSessions.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-vpn-sessions)
-- `VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference](https://docs.maxihost.com/reference/put-vpn-session)
 - `VpnSessions.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/post-vpn-session)
 - `VpnSessions.delete`. Params: `(sessionId)`. [Reference](https://docs.maxihost.com/reference/delete-vpn-session)
+- `VpnSessions.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-vpn-sessions)
+- `VpnSessions.refreshPassword`. Params: `(sessionId)`. [Reference](https://docs.maxihost.com/reference/put-vpn-session)
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ maxihostApi.Profile.get().then((response) => {
 
 - `Plans.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans)
 - `Plans.get`. Params: `(planId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plan)
-- `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system^)
+- `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system)
 
 
 - `Plans.Bandwidth.list`. Params: `()`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
@@ -79,16 +79,16 @@ maxihostApi.Profile.get().then((response) => {
 
 
 - `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.maxihost.com/reference/create-server-action)
-- `Server.Actions.getReinstall`. Params: `(serverId)`. [Reference]()
+-  Deprecated: `Server.Actions.getReinstall`. Params: `(serverId)`.
 - `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/create-server-reinstall)
-- `Server.Actions.getRemoteAccess`. Params: `(serverId)`. [Reference]()
+-  Deprecated: `Server.Actions.getRemoteAccess`. Params: `(serverId)`.
 
 
 - `Server.DeployConfig.get`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/get-server-deploy-config)
 - `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-server-deploy-config)
 
 
-- `Server.Ips.list`. Params: `(serverId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-ips)
+- Deprecated: Use Ips.list instead.`Server.Ips.list`. Params: `(serverId, searchParams)`.
 
 
 - `Server.RemoteAccess.create`. Params: `(serverId)`. [Reference](https://docs.maxihost.com/reference/create-ipmi-session)
@@ -104,7 +104,7 @@ maxihostApi.Profile.get().then((response) => {
 - `Teams.Members.delete`. Params: `(memberId)`. [Reference](https://docs.maxihost.com/reference/destroy-team-member)
 
 
-- `Teams.User.listTeams`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
+- `Teams.User.listTeams`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-user-teams)
 
 
 - `Traffic.get`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-traffic-consumption)

--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ maxihostApi.Profile.get().then((response) => {
 
  
 - `Projects.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-projects)
-- `Projects.get`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project)
-- `Projects.update`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-project)
+- `Projects.get`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project)
+- `Projects.update`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/update-project)
 - `Projects.create`. Params: `(bodyData)`. [Reference](https://docs.maxihost.com/reference/create-project)
-- `Projects.delete`. Params: `(idOrSlug)`. [Reference](https://docs.maxihost.com/reference/delete-project)
+- `Projects.delete`. Params: `(projectIdOrSlug)`. [Reference](https://docs.maxihost.com/reference/delete-project)
 
 
-- `Projects.Members.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
+- `Projects.Members.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
 
 
-- `Projects.SshKeys.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-keys)
-- `Projects.SshKeys.get`. Params: `(projectId, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
-- `Projects.SshKeys.create`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-ssh-key)
-- `Projects.SshKeys.update`. Params: `(projectId, sskKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
-- `Projects.SshKeys.delete`. Params: `(projectId, sshKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
+- `Projects.SshKeys.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-keys)
+- `Projects.SshKeys.get`. Params: `(projectIdOrSlug, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
+- `Projects.SshKeys.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-ssh-key)
+- `Projects.SshKeys.update`. Params: `(projectIdOrSlug, sskKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
+- `Projects.SshKeys.delete`. Params: `(projectIdOrSlug, sshKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
 
 
 - `Projects.UserData.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-users-data)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ maxihostApi.Profile.get().then((response) => {
 
 - `Plans.list`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans)
 - `Plans.get`. Params: `(planId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plan)
-- `Plans.addons`. Params: `(searchParams)`. [Reference]()
 - `Plans.operatingSystems`. Params: `(searchParams)`. [Reference](https://docs.maxihost.com/reference/get-plans-operating-system^)
 
 - `Plans.Bandwidth.list`. Params: `()`. [Reference](https://docs.maxihost.com/reference/get-plans-bandwidth)
@@ -49,28 +48,28 @@ maxihostApi.Profile.get().then((response) => {
 
 - `Projects.Members.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-team-members)
 
-- `Projects.SshKeys.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
+- `Projects.SshKeys.list`. Params: `(projectId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-keys)
 - `Projects.SshKeys.get`. Params: `(projectId, sshKeyId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-ssh-key)
 - `Projects.SshKeys.create`. Params: `(projectId, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-ssh-key)
 - `Projects.SshKeys.update`. Params: `(projectId, sskKeyId, bodyData)`. [Reference](https://docs.maxihost.com/reference/put-project-ssh-key)
 - `Projects.SshKeys.delete`. Params: `(projectId, sshKeyId)`. [Reference](https://docs.maxihost.com/reference/delete-project-ssh-key)
 
 - `Projects.UserData.list`. Params: `(projectIdOrSlug, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-users-data)
-- `Projects.UserData.get`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference]()
-- `Projects.UserData.update`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference]()
-- `Projects.UserData.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference]()
-- `Projects.UserData.delete`. Params: `(projectIdOrSlug, userDataId)`. [Reference]()
+- `Projects.UserData.get`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-project-user-data)
+- `Projects.UserData.update`. Params: `(projectIdOrSlug, userDataId, searchParams)`. [Reference](https://docs.maxihost.com/reference/put-project-user-data)
+- `Projects.UserData.create`. Params: `(projectIdOrSlug, bodyData)`. [Reference](https://docs.maxihost.com/reference/post-project-user-data)
+- `Projects.UserData.delete`. Params: `(projectIdOrSlug, userDataId)`. [Reference](https://docs.maxihost.com/reference/delete-project-user-data)
 
-- `Regions.list`. Params: `(searchParams)` [Reference]()
-- `Regions.get`. Params: `(regionId, searchParams)`. [Reference]()
+- `Regions.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-regions)
+- `Regions.get`. Params: `(regionId, searchParams)`. [Reference](https://docs.maxihost.com/reference/get-region)
 
-- `Server.get`. Params: `(deviceId, searchParams)` [Reference]()
-- `Server.list`. Params: `(searchParams)` [Reference]()
-- `Server.create`. Params: `(bodyData)` [Reference]()
-- `Server.update`. Params: `(deviceId, bodyData)` [Reference]()
-- `Server.delete`. Params: `(deviceId)` [Reference]()
+- `Server.get`. Params: `(deviceId, searchParams)` [Reference](https://docs.maxihost.com/reference/get-server)
+- `Server.list`. Params: `(searchParams)` [Reference](https://docs.maxihost.com/reference/get-servers)
+- `Server.create`. Params: `(bodyData)` [Reference](https://docs.maxihost.com/reference/create-server)
+- `Server.update`. Params: `(deviceId, bodyData)` [Reference](https://docs.maxihost.com/reference/update-server)
+- `Server.delete`. Params: `(deviceId)` [Reference](https://docs.maxihost.com/reference/destroy-server)
 
-- `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference]()
+- `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.maxihost.com/reference/create-server-action)
 - `Server.Actions.getReinstall`. Params: `(serverId)`. [Reference]()
 - `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference]()
 - `Server.Actions.getRemoteAccess`. Params: `(serverId)`. [Reference]()

--- a/lib/resources/account/index.js
+++ b/lib/resources/account/index.js
@@ -1,5 +1,8 @@
 const Regions = require('./regions/index.js');
 
+/**
+ * @deprecated
+ */
 module.exports = Maxihost => {
   Maxihost.prototype.Account = {};
   Maxihost.prototype.Account.Regions = new Regions(Maxihost);

--- a/lib/resources/account/regions/index.js
+++ b/lib/resources/account/regions/index.js
@@ -1,3 +1,6 @@
+/**
+ * @deprecated
+ */
 class Regions {
   constructor(Maxihost) {
     this.Maxihost = Maxihost;

--- a/lib/resources/plans/index.js
+++ b/lib/resources/plans/index.js
@@ -18,6 +18,9 @@ class Plans {
       searchParams);
   }
 
+  /**
+   * @deprecated
+   */
   addons(searchParams = "") {
     searchParams = new URLSearchParams(searchParams).toString()
     return this.Maxihost._get("/plans/addons",

--- a/lib/resources/projects/index.js
+++ b/lib/resources/projects/index.js
@@ -14,19 +14,19 @@ class Projects {
     return this.Maxihost._get(this.baseUrl, headers, searchParams);
   }
 
-  get(projectId, searchParams) {
+  get(projectIdOrSlug, searchParams) {
     searchParams = new URLSearchParams(searchParams).toString();
     const headers = this.Maxihost._headers;
     return this.Maxihost._get(
-      `${this.baseUrl}/${projectId}`,
+      `${this.baseUrl}/${projectIdOrSlug}`,
       headers,
       searchParams
     );
   }
 
-  update(projectId, bodyData) {
+  update(projectIdOrSlug, bodyData) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._patch(`${this.baseUrl}/${projectId}`, headers, bodyData);
+    return this.Maxihost._patch(`${this.baseUrl}/${projectIdOrSlug}`, headers, bodyData);
   }
 
   create(bodyData) {
@@ -34,9 +34,9 @@ class Projects {
     return this.Maxihost._post(`${this.baseUrl}`, headers, bodyData);
   }
 
-  delete(idOrSlug) {
+  delete(projectIdOrSlug) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._delete(`${this.baseUrl}/${idOrSlug}`, headers);
+    return this.Maxihost._delete(`${this.baseUrl}/${projectIdOrSlug}`, headers);
   }
 }
 

--- a/lib/resources/projects/members/index.js
+++ b/lib/resources/projects/members/index.js
@@ -4,10 +4,10 @@ class Members {
     this.baseUrl = '/projects';
   }
 
-  list(projectId, searchParams) {
+  list(projectIdOrSlug, searchParams) {
     searchParams = new URLSearchParams(searchParams).toString()
     const headers = this.Maxihost._headers;
-    return this.Maxihost._get(`${this.baseUrl}/${projectId}/members`, headers, searchParams);
+    return this.Maxihost._get(`${this.baseUrl}/${projectIdOrSlug}/members`, headers, searchParams);
   }
 }
 

--- a/lib/resources/projects/sshKeys/index.js
+++ b/lib/resources/projects/sshKeys/index.js
@@ -4,39 +4,39 @@ class SshKeys {
     this.baseUrl = '/projects';
   }
 
-  list(projectId, searchParams) {
+  list(projectIdOrSlug, searchParams) {
     searchParams = new URLSearchParams(searchParams).toString();
     const headers = this.Maxihost._headers;
     return this.Maxihost._get(
-      `${this.baseUrl}/${projectId}/ssh_keys`,
+      `${this.baseUrl}/${projectIdOrSlug}/ssh_keys`,
       headers,
       searchParams
     );
   }
 
-  get(projectId, sshKeyId, searchParams) {
+  get(projectIdOrSlug, sshKeyId, searchParams) {
     searchParams = new URLSearchParams(searchParams).toString();
     const headers = this.Maxihost._headers;
     return this.Maxihost._get(
-      `${this.baseUrl}/${projectId}/ssh_keys/${sshKeyId}`,
+      `${this.baseUrl}/${projectIdOrSlug}/ssh_keys/${sshKeyId}`,
       headers,
       searchParams
     );
   }
 
-  create(projectId, bodyData) {
+  create(projectIdOrSlug, bodyData) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._post(`${this.baseUrl}/${projectId}/ssh_keys`, headers, bodyData);
+    return this.Maxihost._post(`${this.baseUrl}/${projectIdOrSlug}/ssh_keys`, headers, bodyData);
   }
 
-  update(projectId, sshKeyId, bodyData) {
+  update(projectIdOrSlug, sshKeyId, bodyData) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._patch(`${this.baseUrl}/${projectId}/ssh_keys/${sshKeyId}`, headers, bodyData);
+    return this.Maxihost._patch(`${this.baseUrl}/${projectIdOrSlug}/ssh_keys/${sshKeyId}`, headers, bodyData);
   }
 
-  delete(projectId, sshKeyId) {
+  delete(projectIdOrSlug, sshKeyId) {
     const headers = this.Maxihost._headers;
-    return this.Maxihost._delete(`${this.baseUrl}/${projectId}/ssh_keys/${sshKeyId}`, headers);
+    return this.Maxihost._delete(`${this.baseUrl}/${projectIdOrSlug}/ssh_keys/${sshKeyId}`, headers);
   }
 }
 

--- a/lib/resources/servers/actions/index.js
+++ b/lib/resources/servers/actions/index.js
@@ -12,6 +12,9 @@ class Actions {
     );
   }
 
+  /**
+   * @deprecated
+   */
   getReinstall(serverId) {
     const headers = this.Maxihost._headers;
     return this.Maxihost._get('/servers/' + serverId + '/reinstall', headers);
@@ -26,6 +29,9 @@ class Actions {
     );
   }
 
+  /**
+   * @deprecated
+   */
   getRemoteAccess(serverId) {
     const headers = this.Maxihost._headers;
     return this.Maxihost._get('/servers/' + serverId + '/remote_access', headers);

--- a/lib/resources/servers/ips/index.js
+++ b/lib/resources/servers/ips/index.js
@@ -3,6 +3,9 @@ class Ips {
     this.Maxihost = Maxihost;
   }
 
+  /**
+   * @deprecated
+   */
   list(serverId, searchParams) {
     searchParams = new URLSearchParams(searchParams).toString();
     const headers = this.Maxihost._headers;


### PR DESCRIPTION
This PR updates the documentation. I tried to set up JSDoc but the resulting structure wasn't intuitive. So I have preserved the existing structure.

I have marked any endpoints that no longer exist as deprecated. Should I remove them entirely with a breaking change?

These endpoints are missing in the SDK. I can add support for these in another PR if required.

- [List all Roles](https://docs.maxihost.com/reference/get-roles)
- [Retrieve a Role](https://docs.maxihost.com/reference/get-role-id)
- [Get current API version](https://docs.maxihost.com/reference/get-current-version)
- [Update current API version](https://docs.maxihost.com/reference/update-current-version)
- [Retrieve an IP](https://docs.maxihost.com/reference/get-ip)

Issue: [PD-2234](https://maxihost.atlassian.net/browse/PD-2234)